### PR TITLE
 #1: Remove Guava dependency.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,12 +62,13 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <guava.version>19.0</guava.version>
         <slf4j.version>1.7.21</slf4j.version>
+
+        <guava.version>22.0</guava.version>
 
         <junit.version>4.12</junit.version>
         <hamcrest.version>1.3</hamcrest.version>
-        <mockito.version>1.10.19</mockito.version>
+        <mockito.version>2.8.47</mockito.version>
 
         <maven-compiler-plugin.version>3.5.1</maven-compiler-plugin.version>
         <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
@@ -80,11 +81,6 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>com.google.guava</groupId>
-                <artifactId>guava</artifactId>
-                <version>${guava.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
                 <version>${slf4j.version}</version>
@@ -95,6 +91,15 @@
                 <version>${slf4j.version}</version>
             </dependency>
 
+            <!-- Framework support (provided dependencies -->
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>${guava.version}</version>
+                <scope>provided</scope>
+            </dependency>
+
+            <!-- Test Dependencies -->
             <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -91,14 +91,6 @@
                 <version>${slf4j.version}</version>
             </dependency>
 
-            <!-- Framework support (provided dependencies -->
-            <dependency>
-                <groupId>com.google.guava</groupId>
-                <artifactId>guava</artifactId>
-                <version>${guava.version}</version>
-                <scope>provided</scope>
-            </dependency>
-
             <!-- Test Dependencies -->
             <dependency>
                 <groupId>junit</groupId>

--- a/synapse-core/src/main/java/com/impressiveinteractive/synapse/reflect/Typed.java
+++ b/synapse-core/src/main/java/com/impressiveinteractive/synapse/reflect/Typed.java
@@ -1,0 +1,72 @@
+package com.impressiveinteractive.synapse.reflect;
+
+import com.impressiveinteractive.synapse.exception.Exceptions;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+
+/**
+ * Used to capture generic types. To use it you need to extend {@link Typed} with the actual concrete type that should
+ * be captured. Example:
+ *
+ * <pre>
+ * Typed&lt;List&lt;String&gt;&gt; listOfStrings = new Typed&lt;List&lt;String&gt;&gt;() {};
+ * </pre>
+ *
+ * Based on the TypeToken of Guava, but heavily simplified. Consider using Guava's TypeToken for more complex
+ * operations.
+ *
+ * @param <T> The captured type.
+ */
+public abstract class Typed<T> {
+    private final Type type;
+
+    /**
+     * Create a concrete {@link Typed} instance for the given class.
+     *
+     * @param cls The given class
+     * @param <T> The type this class represents
+     * @return A concrete {@link Typed} instance for the given class.
+     */
+    public static <T> Typed<T> of(Class<T> cls) {
+        return new TypedFromClass<>(cls);
+    }
+
+    /**
+     * Extracts the type from the instantiating type. See example in class JavaDoc.
+     */
+    protected Typed() {
+        Type superType = getClass().getGenericSuperclass();
+        if (!(superType instanceof ParameterizedType))
+            throw Exceptions.format(IllegalArgumentException::new, "Type {} is not a parameterized type.", superType);
+        Type candidate = ((ParameterizedType) superType).getActualTypeArguments()[0];
+        if (!(candidate instanceof Class) && !(candidate instanceof ParameterizedType))
+            throw Exceptions.format(IllegalArgumentException::new, "Type {} is not concrete.", candidate);
+        this.type = candidate;
+    }
+
+    protected Typed(Type type) {
+        this.type = type;
+    }
+
+    /**
+     * @return The captured type.
+     */
+    public final Type getType() {
+        return type;
+    }
+
+    /**
+     * @return The raw {@link Class} representation of the captured type.
+     */
+    @SuppressWarnings("unchecked")
+    public final Class<? super T> getRawType() {
+        return (Class<? super T>) (type instanceof Class ? type : ((ParameterizedType) type).getRawType());
+    }
+
+    private static class TypedFromClass<T> extends Typed<T> {
+        private TypedFromClass(Class<T> cls) {
+            super(cls);
+        }
+    }
+}

--- a/synapse-core/src/test/java/com/impressiveinteractive/synapse/reflect/TypedTest.java
+++ b/synapse-core/src/test/java/com/impressiveinteractive/synapse/reflect/TypedTest.java
@@ -1,0 +1,46 @@
+package com.impressiveinteractive.synapse.reflect;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.List;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class TypedTest {
+    @Rule
+    public final ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void testTypedFromClass() throws Exception {
+        Typed<String> stringTyped = Typed.of(String.class);
+
+        assertThat(stringTyped.getType(), is(equalTo(String.class)));
+        assertThat(stringTyped.getRawType(), is(equalTo(String.class)));
+    }
+
+    @Test
+    public void testSimpleType() throws Exception {
+        Typed<String> stringTyped = new Typed<String>() {};
+
+        assertThat(stringTyped.getType(), is(equalTo(String.class)));
+        assertThat(stringTyped.getRawType(), is(equalTo(String.class)));
+    }
+
+    @Test
+    public void testNestedType() throws Exception {
+        Typed<List<String>> stringTyped = new Typed<List<String>>() {};
+
+        assertThat(stringTyped.getType().getTypeName(), is("java.util.List<java.lang.String>"));
+        assertThat(stringTyped.getRawType(), is(equalTo(List.class)));
+    }
+
+    @Test
+    public <T> void testUnboundType() throws Exception {
+        expectedException.expect(IllegalArgumentException.class);
+        new Typed<T>() {};
+    }
+}

--- a/synapse-test/pom.xml
+++ b/synapse-test/pom.xml
@@ -15,6 +15,7 @@
             <artifactId>synapse-core</artifactId>
             <version>${project.version}</version>
         </dependency>
+
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>

--- a/synapse-test/pom.xml
+++ b/synapse-test/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>synapse</artifactId>
         <groupId>com.impressiveinteractive.synapse</groupId>
@@ -14,11 +15,6 @@
             <groupId>com.impressiveinteractive.synapse</groupId>
             <artifactId>synapse-core</artifactId>
             <version>${project.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
         </dependency>
 
         <dependency>

--- a/synapse-test/src/main/java/com/impressiveinteractive/synapse/test/ChainableMatcher.java
+++ b/synapse-test/src/main/java/com/impressiveinteractive/synapse/test/ChainableMatcher.java
@@ -1,6 +1,5 @@
 package com.impressiveinteractive.synapse.test;
 
-import com.google.common.reflect.TypeToken;
 import com.impressiveinteractive.synapse.lambda.SerializableFunction;
 import com.impressiveinteractive.synapse.reflect.Typed;
 import org.hamcrest.BaseMatcher;
@@ -60,17 +59,6 @@ public class ChainableMatcher<T> extends BaseMatcher<T> {
      * @return A new {@link ChainableMatcher} for the given type.
      */
     public static <T> ChainableMatcher<T> ofType(Typed<T> type) {
-        return new ChainableMatcher<>(type);
-    }
-
-    /**
-     * Create a new {@link ChainableMatcher} for the given type.
-     *
-     * @param type The given type.
-     * @param <T>  The type of the object being matched.
-     * @return A new {@link ChainableMatcher} for the given type.
-     */
-    public static <T> ChainableMatcher<T> ofType(TypeToken<T> type) {
         return new ChainableMatcher<>(type);
     }
 
@@ -192,15 +180,6 @@ public class ChainableMatcher<T> extends BaseMatcher<T> {
      */
     public ChainableMatcher(Typed<T> type) {
         this.type = type;
-    }
-
-    /**
-     * Create a new {@link ChainableMatcher} for the given type.
-     *
-     * @param typeToken The given type.
-     */
-    public ChainableMatcher(TypeToken<T> typeToken) {
-        this(new Typed<T>(typeToken.getType()) {});
     }
 
     @Override

--- a/synapse-test/src/main/java/com/impressiveinteractive/synapse/test/ChainableMatcher.java
+++ b/synapse-test/src/main/java/com/impressiveinteractive/synapse/test/ChainableMatcher.java
@@ -2,6 +2,7 @@ package com.impressiveinteractive.synapse.test;
 
 import com.google.common.reflect.TypeToken;
 import com.impressiveinteractive.synapse.lambda.SerializableFunction;
+import com.impressiveinteractive.synapse.reflect.Typed;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
@@ -38,7 +39,7 @@ public class ChainableMatcher<T> extends BaseMatcher<T> {
     private static final String LAMBDA_NAME = "<lambda>";
 
     private final List<FieldMatcher<?>> fieldMatchers = new ArrayList<>();
-    private final TypeToken<T> type;
+    private final Typed<T> type;
 
     /**
      * Create a new {@link ChainableMatcher} for the given type.
@@ -49,6 +50,17 @@ public class ChainableMatcher<T> extends BaseMatcher<T> {
      */
     public static <T> ChainableMatcher<T> ofType(Class<T> cls) {
         return new ChainableMatcher<>(cls);
+    }
+
+    /**
+     * Create a new {@link ChainableMatcher} for the given type.
+     *
+     * @param type The given type.
+     * @param <T>  The type of the object being matched.
+     * @return A new {@link ChainableMatcher} for the given type.
+     */
+    public static <T> ChainableMatcher<T> ofType(Typed<T> type) {
+        return new ChainableMatcher<>(type);
     }
 
     /**
@@ -140,11 +152,11 @@ public class ChainableMatcher<T> extends BaseMatcher<T> {
         String name;
         String methodName = serialized.getImplMethodName();
         if (isGetterLike(serialized)) {
-            if(isGetter(serialized)) {
+            if (isGetter(serialized)) {
                 String nameWithCapitalStart = methodName.replaceAll("^(get|is)([A-Z].*$)", "$2");
                 name = nameWithCapitalStart.substring(0, 1).toLowerCase()
                         + nameWithCapitalStart.substring(1, nameWithCapitalStart.length());
-            }else{
+            } else {
                 name = methodName + "()";
             }
         } else if (methodName.startsWith("lambda")) {
@@ -170,7 +182,7 @@ public class ChainableMatcher<T> extends BaseMatcher<T> {
      * @param cls The given (simple) type.
      */
     public ChainableMatcher(Class<T> cls) {
-        this(TypeToken.of(cls));
+        this(Typed.of(cls));
     }
 
     /**
@@ -178,8 +190,17 @@ public class ChainableMatcher<T> extends BaseMatcher<T> {
      *
      * @param type The given type.
      */
-    public ChainableMatcher(TypeToken<T> type) {
+    public ChainableMatcher(Typed<T> type) {
         this.type = type;
+    }
+
+    /**
+     * Create a new {@link ChainableMatcher} for the given type.
+     *
+     * @param typeToken The given type.
+     */
+    public ChainableMatcher(TypeToken<T> typeToken) {
+        this(new Typed<T>(typeToken.getType()) {});
     }
 
     @Override
@@ -187,10 +208,8 @@ public class ChainableMatcher<T> extends BaseMatcher<T> {
     public boolean matches(Object o) {
         if (type.getRawType().isInstance(o)) {
             T instance = (T) o;
-            return !fieldMatchers.stream()
-                    .filter(matcher -> !matcher.matches(instance))
-                    .findAny()
-                    .isPresent();
+            return fieldMatchers.stream()
+                    .allMatch(matcher -> matcher.matches(instance));
         }
         return false;
     }

--- a/synapse-test/src/test/java/com/impressiveinteractive/synapse/test/ChainableMatcherTest.java
+++ b/synapse-test/src/test/java/com/impressiveinteractive/synapse/test/ChainableMatcherTest.java
@@ -1,6 +1,5 @@
 package com.impressiveinteractive.synapse.test;
 
-import com.google.common.reflect.TypeToken;
 import com.impressiveinteractive.synapse.lambda.SerializableFunction;
 import com.impressiveinteractive.synapse.reflect.Typed;
 import org.hamcrest.Matcher;
@@ -208,15 +207,6 @@ public class ChainableMatcherTest {
         List<String> strings = singletonList("String value");
 
         assertThat(strings, is(ofType(new Typed<List<String>>() {})
-                .where(List::size, is(1))
-                .where("get(0)", l -> l.get(0), is("String value"))));
-    }
-
-    @Test
-    public void testCreateFromTypeToken() throws Exception {
-        List<String> strings = singletonList("String value");
-
-        assertThat(strings, is(ofType(new TypeToken<List<String>>() {})
                 .where(List::size, is(1))
                 .where("get(0)", l -> l.get(0), is("String value"))));
     }

--- a/synapse-test/src/test/java/com/impressiveinteractive/synapse/test/ChainableMatcherTest.java
+++ b/synapse-test/src/test/java/com/impressiveinteractive/synapse/test/ChainableMatcherTest.java
@@ -1,6 +1,8 @@
 package com.impressiveinteractive.synapse.test;
 
+import com.google.common.reflect.TypeToken;
 import com.impressiveinteractive.synapse.lambda.SerializableFunction;
+import com.impressiveinteractive.synapse.reflect.Typed;
 import org.hamcrest.Matcher;
 import org.hamcrest.StringDescription;
 import org.junit.Test;
@@ -12,6 +14,7 @@ import java.util.stream.Stream;
 
 import static com.impressiveinteractive.synapse.test.ChainableMatcher.map;
 import static com.impressiveinteractive.synapse.test.ChainableMatcher.ofType;
+import static java.util.Collections.singletonList;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
@@ -198,6 +201,24 @@ public class ChainableMatcherTest {
         assertThat(matcher.matches(couple), is(false)); // Maria is not a male
 
         assertThat(describeMismatch(matcher, couple), startsWith("has unexpected value for:\n\tmales item 0:"));
+    }
+
+    @Test
+    public void testCreateFromTyped() throws Exception {
+        List<String> strings = singletonList("String value");
+
+        assertThat(strings, is(ofType(new Typed<List<String>>() {})
+                .where(List::size, is(1))
+                .where("get(0)", l -> l.get(0), is("String value"))));
+    }
+
+    @Test
+    public void testCreateFromTypeToken() throws Exception {
+        List<String> strings = singletonList("String value");
+
+        assertThat(strings, is(ofType(new TypeToken<List<String>>() {})
+                .where(List::size, is(1))
+                .where("get(0)", l -> l.get(0), is("String value"))));
     }
 
     // Protected method


### PR DESCRIPTION
Completed #1. Instead of removing Guava altogether, I've set the dependency scope to "provided". The code will work with the new `Typed` class, but also with the TypeToken.