### PR TITLE
#6: Remove SLF4J dependency, replace functionality with ExceptionalMessage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.impressiveinteractive.synapse</groupId>
@@ -63,7 +64,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <guava.version>19.0</guava.version>
-        <slf4j.version>1.7.21</slf4j.version>
 
         <junit.version>4.12</junit.version>
         <hamcrest.version>1.3</hamcrest.version>
@@ -83,16 +83,6 @@
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
                 <version>${guava.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-api</artifactId>
-                <version>${slf4j.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-simple</artifactId>
-                <version>${slf4j.version}</version>
             </dependency>
 
             <dependency>

--- a/synapse-core/pom.xml
+++ b/synapse-core/pom.xml
@@ -11,17 +11,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>${slf4j.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/synapse-core/src/main/java/com/impressiveinteractive/synapse/exception/ExceptionalMessage.java
+++ b/synapse-core/src/main/java/com/impressiveinteractive/synapse/exception/ExceptionalMessage.java
@@ -1,0 +1,120 @@
+package com.impressiveinteractive.synapse.exception;
+
+import java.util.Arrays;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A container for a message that may or may not come with a {@link Throwable}. Use {@link #parse(String, Object...)} to
+ * create an ExceptionalMessage in the SLF4J format.
+ */
+public class ExceptionalMessage {
+    private static final int ESCAPE = '\\';
+    private static final int VAR_OPEN = '{';
+    private static final int VAR_CLOSE = '}';
+
+    private final String message;
+    private final Throwable throwable;
+
+    /**
+     * Create an {@link ExceptionalMessage} from the given format string and args. This method has been created to work
+     * exactly like log messages with SLF4J. Each occurrence of the string literal {@code {}} will be replaced in order
+     * with {@link Object#toString()} from the args array. Example:
+     *
+     * <pre>
+     * assertThat(ExceptionalMessage.parse("This is a {}", "test").getMessage(),
+     *     is("This is a test"));
+     * assertThat(ExceptionalMessage.parse("This is a {},{},{}", 1, 2, 3).getMessage(),
+     *     is("This is a 1,2,3"));
+     * </pre>
+     *
+     * The string literal {@code {}} can be escaped with a {@code \}. Example: {@code "\\{}"}. You can also escape the
+     * backslash if you wish to have the literal {@code \}. Escaping has no effect in other situations.
+     * <p>
+     * When the final element of {@code args} is a {@link Throwable}, this exception will end up in
+     * {@link ExceptionalMessage#getThrowable()}. This {@link Throwable} will not be used in message substitution.
+     *
+     * @param format The message format, where {@code {}} will bre replaced with elements from {@code args}.
+     * @param args   Used to fill {@code {}} inside the format message.
+     * @return An {@link ExceptionalMessage} with a message generated from {@code format} and {@code args} and
+     * optionally a throwable, if this was the last element in the {@code args} array.
+     */
+    public static ExceptionalMessage parse(String format, Object... args) {
+        StringBuilder messageBuilder = new StringBuilder();
+
+        Object[] values;
+        int valuesIndex = 0;
+        Throwable throwable;
+        if (args.length > 0 && args[args.length - 1] instanceof Throwable) {
+            values = Arrays.copyOfRange(args, 0, args.length - 1);
+            throwable = (Throwable) args[args.length - 1];
+        } else {
+            values = args;
+            throwable = null;
+        }
+
+        boolean escaped = false;
+        boolean open = false;
+
+        int index = 0;
+        while (index < format.length()) {
+            int codePoint = format.codePointAt(index);
+            if (open) {
+                if (codePoint == VAR_CLOSE) {
+                    if (escaped) {
+                        messageBuilder.appendCodePoint(VAR_OPEN).appendCodePoint(VAR_CLOSE);
+                        escaped = false;
+                    } else if (valuesIndex < values.length) {
+                        messageBuilder.append(values[valuesIndex++]);
+                    } else {
+                        messageBuilder.appendCodePoint(VAR_OPEN).appendCodePoint(VAR_CLOSE);
+                    }
+                } else {
+                    messageBuilder.appendCodePoint(VAR_OPEN).appendCodePoint(codePoint);
+                }
+                open = false;
+            } else if (codePoint == VAR_OPEN) {
+                open = true;
+            } else if (codePoint == ESCAPE) {
+                if (escaped) {
+                    messageBuilder.appendCodePoint(ESCAPE);
+                } else {
+                    escaped = true;
+                }
+            } else {
+                if (escaped) {
+                    messageBuilder.appendCodePoint(ESCAPE);
+                    escaped = false;
+                }
+                messageBuilder.appendCodePoint(codePoint);
+            }
+            index += Character.charCount(codePoint);
+        }
+        return new ExceptionalMessage(messageBuilder.toString(), throwable);
+    }
+
+    /**
+     * Create a new {@link ExceptionalMessage}.
+     *
+     * @param message   The string message, can not be null.
+     * @param throwable The throwable, can be null.
+     */
+    public ExceptionalMessage(String message, Throwable throwable) {
+        this.message = requireNonNull(message);
+        this.throwable = throwable;
+    }
+
+    /**
+     * @return The string message.
+     */
+    public String getMessage() {
+        return message;
+    }
+
+    /**
+     * @return The {@link Throwable}, or null.
+     */
+    public Throwable getThrowable() {
+        return throwable;
+    }
+}

--- a/synapse-core/src/main/java/com/impressiveinteractive/synapse/exception/Exceptions.java
+++ b/synapse-core/src/main/java/com/impressiveinteractive/synapse/exception/Exceptions.java
@@ -1,8 +1,5 @@
 package com.impressiveinteractive.synapse.exception;
 
-import org.slf4j.helpers.FormattingTuple;
-import org.slf4j.helpers.MessageFormatter;
-
 import java.util.Arrays;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
@@ -41,8 +38,8 @@ public final class Exceptions {
      */
     public static <T extends Throwable> T format(
             BiFunction<String, Throwable, T> constructor, String message, Object... args) {
-        FormattingTuple tuple = MessageFormatter.arrayFormat(message, args);
-        return reduceStackTrace(constructor.apply(tuple.getMessage(), tuple.getThrowable()));
+        ExceptionalMessage exceptionalMessage = ExceptionalMessage.parse(message, args);
+        return reduceStackTrace(constructor.apply(exceptionalMessage.getMessage(), exceptionalMessage.getThrowable()));
     }
 
     /**
@@ -70,15 +67,15 @@ public final class Exceptions {
      */
     public static <T extends Throwable> T formatMessage(
             Function<String, T> constructor, String message, Object... args) {
-        FormattingTuple tuple = MessageFormatter.arrayFormat(message, args);
-        Throwable throwable = tuple.getThrowable();
+        ExceptionalMessage exceptionalMessage = ExceptionalMessage.parse(message, args);
+        Throwable throwable = exceptionalMessage.getThrowable();
         if (throwable != null) {
             IllegalArgumentException iae = new IllegalArgumentException(
                     "Unexpected throwable when formatting message.", throwable);
-            iae.addSuppressed(reduceStackTrace(constructor.apply(tuple.getMessage())));
+            iae.addSuppressed(reduceStackTrace(constructor.apply(exceptionalMessage.getMessage())));
             throw iae;
         }
-        return reduceStackTrace(constructor.apply(tuple.getMessage()));
+        return reduceStackTrace(constructor.apply(exceptionalMessage.getMessage()));
     }
 
     /**
@@ -297,7 +294,7 @@ public final class Exceptions {
     }
 
     /**
-     * Short for {@link #wrapExceptionalFunction(ExceptionalFunction, Function)} 
+     * Short for {@link #wrapExceptionalFunction(ExceptionalFunction, Function)}
      * <p>
      * Wrap the given {@link ExceptionalFunction} in a regular {@link Function}. When the exceptional function throws
      * the checked exception type, it will be wrapped and thrown as the {@link RuntimeException} produced by the given

--- a/synapse-core/src/test/java/com/impressiveinteractive/synapse/exception/ExceptionalMessageTest.java
+++ b/synapse-core/src/test/java/com/impressiveinteractive/synapse/exception/ExceptionalMessageTest.java
@@ -1,0 +1,61 @@
+package com.impressiveinteractive.synapse.exception;
+
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+public class ExceptionalMessageTest {
+
+    private static final RuntimeException EXCEPTION = new RuntimeException();
+
+    @Test
+    public void compareMessageWithSlf4j() throws Exception {
+        assertThat(ExceptionalMessage.parse("This is a test").getMessage(),
+                is("This is a test"));
+        assertThat(ExceptionalMessage.parse("This is a {}", "test").getMessage(),
+                is("This is a test"));
+        assertThat(ExceptionalMessage.parse("Testing {},{},{}", 1, 2, 3).getMessage(),
+                is("Testing 1,2,3"));
+        assertThat(ExceptionalMessage.parse("Testing {},{},{}", "test").getMessage(),
+                is("Testing test,{},{}"));
+        assertThat(ExceptionalMessage.parse("This is a {test}", "test").getMessage(),
+                is("This is a {test}"));
+
+
+        assertThat(ExceptionalMessage.parse("This is a \\{}", "test").getMessage(),
+                is("This is a {}"));
+        assertThat(ExceptionalMessage.parse("This is a \\ {}", "test").getMessage(),
+                is("This is a \\ test"));
+        assertThat(ExceptionalMessage.parse("This is a \\\\ {}", "test").getMessage(),
+                is("This is a \\\\ test"));
+        assertThat(ExceptionalMessage.parse("This is a {\\}", "test").getMessage(),
+                is("This is a {\\}"));
+
+        assertThat(ExceptionalMessage.parse("This is a {}", "test", EXCEPTION).getMessage(),
+                is("This is a test"));
+        assertThat(ExceptionalMessage.parse("This is a {} {}", "test", EXCEPTION).getMessage(),
+                is("This is a test {}"));
+        assertThat(ExceptionalMessage.parse("This is a test", "test", EXCEPTION).getMessage(),
+                is("This is a test"));
+        assertThat(ExceptionalMessage.parse("This is a {} {}", EXCEPTION, "test").getMessage(),
+                is("This is a java.lang.RuntimeException test"));
+    }
+
+    @Test
+    public void compareThrowableWithSlf4j() throws Exception {
+        assertThat(ExceptionalMessage.parse("This is a test").getThrowable(),
+                is(nullValue()));
+        assertThat(ExceptionalMessage.parse("This is a {}", "test").getThrowable(),
+                is(nullValue()));
+        assertThat(ExceptionalMessage.parse("This is a {}", "test", EXCEPTION).getThrowable(),
+                is(EXCEPTION));
+        assertThat(ExceptionalMessage.parse("This is a {} {}", "test", EXCEPTION).getThrowable(),
+                is(EXCEPTION));
+        assertThat(ExceptionalMessage.parse("This is a test", "test", EXCEPTION).getThrowable(),
+                is(EXCEPTION));
+        assertThat(ExceptionalMessage.parse("This is a {} {}", EXCEPTION, "test").getThrowable(),
+                is(nullValue()));
+    }
+}


### PR DESCRIPTION
The tests first used SLF4J to see if the behaviour matched. I later removed SLF4J altogether.